### PR TITLE
Four issues resolution

### DIFF
--- a/Screw1132_Overkill.sh
+++ b/Screw1132_Overkill.sh
@@ -11,11 +11,20 @@ LOG="$HOME/zoom_fix.log"
 VERSION="3.0.0"
 ZOOM_URL="https://zoom.us/client/latest/Zoom.pkg"
 BACKUP_DIR="$HOME/.zoom_backup_$(date +%Y%m%d_%H%M%S)"
+MIN_MACOS_VERSION="10.15.0"
 
 # Logging setup
 exec > >(tee -i "$LOG") 2>&1
 
 USAGE="Usage: $0 [-f|--force] [-v|--version] [-h|--help] [-d|--deep-clean]"
+
+version_to_number() {
+  local version="$1"
+  local IFS='.'
+  local parts
+  read -r -a parts <<< "$version"
+  printf "%03d%03d%03d" "${parts[0]:-0}" "${parts[1]:-0}" "${parts[2]:-0}"
+}
 
 # ─── 0. Parse flags ───────────────────────────────────────
 FORCE=false
@@ -36,7 +45,14 @@ echo "🔍 Checking system requirements..."
 
 # Check macOS version for compatibility
 MACOS_VERSION=$(sw_vers -productVersion)
-echo "✅ macOS version: $MACOS_VERSION"
+CURRENT_VERSION_NUM=$(version_to_number "$MACOS_VERSION")
+MIN_VERSION_NUM=$(version_to_number "$MIN_MACOS_VERSION")
+if ((10#$CURRENT_VERSION_NUM < 10#$MIN_VERSION_NUM)); then
+  echo "❌ Unsupported macOS version: $MACOS_VERSION"
+  echo "   Minimum required version: $MIN_MACOS_VERSION"
+  exit 1
+fi
+echo "✅ macOS version: $MACOS_VERSION (minimum supported: $MIN_MACOS_VERSION)"
 
 for cmd in sudo curl openssl networksetup pkgutil system_profiler; do
   command -v "$cmd" &>/dev/null || { echo "❌ Missing $cmd."; exit 1; }

--- a/Screw1132_Overkill.sh
+++ b/Screw1132_Overkill.sh
@@ -257,6 +257,10 @@ sudo rm -rf /var/folders/*/com.apple.Safari* 2>/dev/null || true
 BROWSER_CACHES=(
   "$HOME/Library/Application Support/Google/Chrome/Default/Cache"
   "$HOME/Library/Application Support/Google/Chrome/Default/Code Cache"
+  "$HOME/Library/Application Support/Microsoft Edge/Default/Cache"
+  "$HOME/Library/Application Support/Microsoft Edge/Default/Code Cache"
+  "$HOME/Library/Application Support/BraveSoftware/Brave-Browser/Default/Cache"
+  "$HOME/Library/Application Support/BraveSoftware/Brave-Browser/Default/Code Cache"
   "$HOME/Library/Application Support/Mozilla/Firefox/Profiles/*/cache2"
   "$HOME/Library/Safari/LocalStorage"
   "$HOME/Library/Safari/WebpageIcons.db"


### PR DESCRIPTION
Implements fixes for four GitHub issues: extending browser cache cleanup, removing the disk space check, adding macOS version validation, and using Installomator for Zoom fallback.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-588dfbbc-8cb4-482c-bcf6-cc60a4325fe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-588dfbbc-8cb4-482c-bcf6-cc60a4325fe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Zoom install path and introduces an external Installomator fallback, which can affect reliability and behavior on failure paths. The removal of the disk-space precheck also increases the chance of running out of space mid-install.
> 
> **Overview**
> Improves `Screw1132_Overkill.sh` resilience and compatibility checks by adding a minimum macOS version gate (`10.15.0`) using a new `version_to_number` helper.
> 
> Removes the disk-space preflight check, expands browser cache cleanup to include Edge and Brave, and updates the Zoom install flow to fall back to installing/running `Installomator` when the direct Zoom package download fails (with temp pkg cleanup afterwards).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf47fc0247f6c16833d5befb6732a76d3c281dc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->