### PR TITLE
Add AGENTS.md for Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+Zoom Nuke is a **macOS-only** privacy/cleanup tool (shell scripts + SwiftUI GUI app). The core product is shell scripts (`zoom_nuke.sh`, `zoom_nuke_overkill.sh`) and a native macOS SwiftUI app (`app/`). There are no backend services, databases, or Docker containers.
+
+### What runs on the Linux Cloud VM
+
+Only shell-script linting and syntax validation can run on the Linux VM. The Swift/SwiftUI build and all macOS runtime tests (`--version`, `--audit`, `--dry-run`, preflight) require macOS. The `tools/validate.sh` script auto-skips macOS-only sections when `uname` is not `Darwin`.
+
+### Lint
+
+```bash
+shellcheck --severity=warning \
+  zoom_nuke.sh zoom_nuke_overkill.sh "Start Zoom Nuke.command" \
+  tools/_zoom_core.sh tools/mac_spoof.sh tools/zoom_protection.sh \
+  tools/build_macos_app.sh tools/build_release_bundle.sh \
+  tools/build_pkg_installer.sh tools/preflight_check.sh tools/validate.sh
+```
+
+There are two pre-existing SC2034 warnings in `tools/preflight_check.sh` (unused variables `MDM_ENROLLED` and `MAC_SPOOF_OK`). These are used in the `--json` output path and are false positives.
+
+### Validate (smoke tests + syntax)
+
+```bash
+./tools/validate.sh --verbose
+```
+
+This runs repository structure checks, shell syntax (`bash -n`), and on macOS also runs CLI flag validation, `--audit` mode, and preflight checks.
+
+### Build (macOS only)
+
+The Swift app builds via SPM: `swift build`. The distributable `.app` bundle is built with `./tools/build_macos_app.sh`. Both require macOS with Xcode/Swift toolchain.
+
+### CI
+
+See `.github/workflows/pr-validate.yml` — runs shellcheck on Ubuntu, and Swift build + validate + preflight on macOS.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for developing in this macOS-only codebase on a Linux Cloud VM.

## What's included

- **Project overview** — Zoom Nuke is a macOS-only tool (shell scripts + SwiftUI app) with no backend services
- **Linux VM capabilities** — Documents what can and cannot run on the Linux Cloud VM (shellcheck linting and `bash -n` syntax validation work; Swift build and macOS runtime tests require macOS)
- **Lint/validate/build commands** — Quick-reference commands for the most common dev tasks
- **CI reference** — Points to `.github/workflows/pr-validate.yml` for the full CI pipeline

## Environment verification

All Linux-compatible checks pass:

[validate_output.log](https://cursor.com/artifacts/c/art-7f5c7b0a-ec82-4c72-af3c-26585cdc5aed)

Shellcheck runs successfully with only two pre-existing SC2034 warnings in `tools/preflight_check.sh`:

[shellcheck_output.log](https://cursor.com/artifacts/c/art-da2f050c-f179-4f6f-826c-557f5721f121)

## Update script

The VM startup script installs `shellcheck` (the only external dev dependency needed on Linux).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b52baaf4-2089-4a91-a253-4d4bd3b17b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b52baaf4-2089-4a91-a253-4d4bd3b17b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

