### PR TITLE
fix: replace exec with plain invocation so EXIT trap actually fires

### DIFF
--- a/tools/zoom_protection.sh
+++ b/tools/zoom_protection.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # zoom_protection.sh
 #
-# Hardware fingerprint protection wrapper for Zoom.
+# Hostname-spoofing launch wrapper for Zoom.
 # Spoofs the system hostname via scutil (so gethostname(2) returns the spoofed
 # value to all child processes, including Zoom). Restores the original names on
 # EXIT via trap so no permanent change is made even if Zoom crashes.
@@ -13,7 +13,7 @@
 
 set -uo pipefail
 
-ZOOM_BIN="/Applications/zoom.us.app/Contents/MacOS/zoom.us"
+ZOOM_BIN="${ZOOM_BIN:-/Applications/zoom.us.app/Contents/MacOS/zoom.us}"
 
 if [[ ! -x "$ZOOM_BIN" ]]; then
   echo "❌ Zoom executable not found at $ZOOM_BIN" >&2
@@ -66,4 +66,4 @@ rm -f  "$ZOOM_DATA/viper.ini"                       2>/dev/null || true
 
 # ── Launch Zoom (replaces this process; trap still fires on its exit) ─────
 echo "🚀 Launching Zoom..."
-exec "$ZOOM_BIN" "$@"
+"$ZOOM_BIN" "$@"

--- a/zoom_nuke_overkill.sh
+++ b/zoom_nuke_overkill.sh
@@ -392,7 +392,7 @@ sudo scutil --set HostName "$SPOOF_NAME" 2>/dev/null \
 rm -rf "$HOME/Library/Caches/us.zoom.xos" 2>/dev/null || true
 rm -rf "$HOME/Library/Application Support/zoom.us/data"/*.db 2>/dev/null || true
 rm -f  "$HOME/Library/Application Support/zoom.us/data/viper.ini" 2>/dev/null || true
-exec "$ZOOM_BIN" "$@"
+"$ZOOM_BIN" "$@"
 PROTECTION_EOF
     chmod +x "$PROTECTION_SCRIPT"
     echo "✅ Protection script created (inline fallback): $PROTECTION_SCRIPT"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk shell-script change that only alters how Zoom is launched to ensure EXIT traps restore spoofed hostnames; potential impact limited to wrapper behavior if Zoom is expected to replace the current process.
> 
> **Overview**
> Ensures the hostname-spoofing Zoom launch wrappers actually run their `EXIT` traps by replacing `exec "$ZOOM_BIN" "$@"` with a normal invocation, so hostname restoration happens when Zoom exits.
> 
> Also makes `tools/zoom_protection.sh` respect an overridable `ZOOM_BIN` environment variable (defaulting to the standard app path) and updates the header comment to reflect hostname spoofing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a818e34e93d4c588f93f471ef90d5ea4b1907b9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->